### PR TITLE
Fix error from class to className

### DIFF
--- a/src/components/layout/Navigation.jsx
+++ b/src/components/layout/Navigation.jsx
@@ -15,7 +15,7 @@ const Navigation = () => {
   //MENU
   const smallMenu = (
     <div className="navigation__button" onClick={openMenuHandler}>
-      <span class="navigation__icon">&nbsp;</span>
+      <span className="navigation__icon">&nbsp;</span>
     </div>
   );
 


### PR DESCRIPTION
### Description
corrected an error where the 'class' attribute was used instead of 'className'