### PR TITLE
Add netlify.toml file to fix page not found on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
### Description
Add netlify.toml file to the root directory to fix page not found on Netlify